### PR TITLE
Version updates and minor changes

### DIFF
--- a/benchs/src/main/scala/ReadersBenchmark.scala
+++ b/benchs/src/main/scala/ReadersBenchmark.scala
@@ -9,6 +9,9 @@ import models.{ParsingResult, BidRequestReader}
 
 @State(Scope.Benchmark)
 abstract class ReadersBenchmark(file: File) {
+  val source = scala.io.Source.fromFile(file)(Codec.UTF8)
+  val lines = source.getLines().toVector
+  source.close()
 
   def run(file: File, reader: BidRequestReader): Unit = {
     val source = scala.io.Source.fromFile(file)(Codec.UTF8)
@@ -28,11 +31,9 @@ abstract class ReadersBenchmark(file: File) {
   @Benchmark
   def bench(): Unit = {
     val reader = Referential.readers(readerName)
-    val source = scala.io.Source.fromFile(file)(Codec.UTF8)
-    val result = source.getLines().foldLeft(ParsingResult(0, 0, 0)) { case (r, line) =>
+    val result = lines.iterator.foldLeft(ParsingResult(0, 0, 0)) { case (r, line) =>
       reader.parse(line, r)
     }
-    source.close()
 
     assert(result.cannotParse == 0)
     assert(result.cannotUnmarshal == 0)

--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ lazy val benchs = (project in file("benchs"))
   .enablePlugins(JmhPlugin)
 
 libraryDependencies in ThisBuild ++= Seq(
-  "org.spire-math" %% "jawn-parser" % "0.8.3"
+  "org.spire-math" %% "jawn-parser" % "0.8.4"
 )
 
 lazy val common = (project in file("parsers/common"))
@@ -20,42 +20,42 @@ lazy val common = (project in file("parsers/common"))
 lazy val playjson = (project in file("parsers/play"))
   .settings(
     libraryDependencies ++= Seq(
-      "com.typesafe.play" %% "play-json" % "2.3.6",
-      "org.spire-math" %% "jawn-play" % "0.8.3"
+      "com.typesafe.play" %% "play-json" % "2.4.2",
+      "org.spire-math" %% "jawn-play" % "0.8.4"
     )
   ).dependsOn(common)
 
 lazy val circe = (project in file("parsers/circe"))
   .settings(
     libraryDependencies ++= Seq(
-      "io.circe" %% "circe-core" % "0.2.1",
-      "io.circe" %% "circe-generic" % "0.2.1",
-      "io.circe" %% "circe-parse" % "0.2.1"
+      "io.circe" %% "circe-core" % "0.3.0",
+      "io.circe" %% "circe-generic" % "0.3.0",
+      "io.circe" %% "circe-parser" % "0.3.0"
     )
   ).dependsOn(common)
 
 lazy val json4s = (project in file("parsers/json4s"))
   .settings(
     libraryDependencies ++= Seq(
-      "org.json4s" %% "json4s-native" % "3.2.11",
-      "org.json4s" %% "json4s-jackson" % "3.2.11",
-      "org.spire-math" %% "jawn-json4s" % "0.8.3"
+      "org.json4s" %% "json4s-native" % "3.3.0",
+      "org.json4s" %% "json4s-jackson" % "3.3.0",
+      "org.spire-math" %% "jawn-json4s" % "0.8.4"
     )
   ).dependsOn(common)
 
 lazy val argonaut = (project in file("parsers/argonaut"))
   .settings(
     libraryDependencies ++= Seq(
-      "io.argonaut" %% "argonaut" % "6.0.4",
-      "org.spire-math" %% "jawn-argonaut" % "0.8.3"
+      "io.argonaut" %% "argonaut" % "6.1",
+      "org.spire-math" %% "jawn-argonaut" % "0.8.4"
     )
   ).dependsOn(common)
 
 lazy val spray = (project in file("parsers/spray"))
   .settings(
     libraryDependencies ++= Seq(
-      "io.spray" %%  "spray-json" % "1.3.1",
-      "org.spire-math" %% "jawn-spray" % "0.8.3"
+      "io.spray" %%  "spray-json" % "1.3.2",
+      "org.spire-math" %% "jawn-spray" % "0.8.4"
     )
   ).dependsOn(common)
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.9
+sbt.version=0.13.11

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.2.4")
+addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.2.6")


### PR DESCRIPTION
As discussed on [Gitter](https://gitter.im/travisbrown/circe?at=56dcb66068ddef7764691d5e).

I added a comment in the circe implementation noting that ~25 lines of boilerplate there aren't strictly necessary—you could switch from `semiauto` to `auto`, delete those lines, and everything would run exactly the same _except_ that the compilation time would be about ten times longer (from a few seconds to over a minute). This seems like a good enough reason to use `semiauto`, but it's nice to know that `auto` works for this fairly complex data model.

Updated results on my machine (lower is better):
```
[info] Benchmark                         (readerName)  Mode  Cnt   Score   Error  Units
[info] OneFileReadersbenchmarks.bench      spray-jawn  avgt    2   7.241           s/op
[info] OneFileReadersbenchmarks.bench           spray  avgt    2   9.696           s/op
[info] OneFileReadersbenchmarks.bench      circe-jawn  avgt    2  13.763           s/op
[info] OneFileReadersbenchmarks.bench   argonaut-jawn  avgt    2  15.333           s/op
[info] OneFileReadersbenchmarks.bench       play-jawn  avgt    2  19.424           s/op
[info] OneFileReadersbenchmarks.bench            play  avgt    2  21.806           s/op
[info] OneFileReadersbenchmarks.bench     json4s-jawn  avgt    2  30.879           s/op
[info] OneFileReadersbenchmarks.bench  json4s-jackson  avgt    2  32.349           s/op
[info] OneFileReadersbenchmarks.bench          json4s  avgt    2  33.131           s/op
```

As we've discussed in a few places, it's really hard to compete with Spray JSON (which just throws relatively useless exceptions on failure) if you're modeling failures as values and keeping track of history to support informative error messages. I have a plan for circe 0.5 that I hope will close the gap a bit by allowing less information to be dragged around during decoding if you don't need it.