### PR TITLE
Update circe and other versions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ lazy val benchs = (project in file("benchs"))
   .enablePlugins(JmhPlugin)
 
 libraryDependencies in ThisBuild ++= Seq(
-  "org.spire-math" %% "jawn-parser" % "0.8.4"
+  "org.spire-math" %% "jawn-parser" % "0.10.4"
 )
 
 lazy val common = (project in file("parsers/common"))
@@ -20,42 +20,42 @@ lazy val common = (project in file("parsers/common"))
 lazy val playjson = (project in file("parsers/play"))
   .settings(
     libraryDependencies ++= Seq(
-      "com.typesafe.play" %% "play-json" % "2.4.2",
-      "org.spire-math" %% "jawn-play" % "0.8.4"
+      "com.typesafe.play" %% "play-json" % "2.5.10",
+      "org.spire-math" %% "jawn-play" % "0.10.4"
     )
   ).dependsOn(common)
 
 lazy val circe = (project in file("parsers/circe"))
   .settings(
     libraryDependencies ++= Seq(
-      "io.circe" %% "circe-core" % "0.4.0",
-      "io.circe" %% "circe-generic" % "0.4.0",
-      "io.circe" %% "circe-parser" % "0.4.0"
+      "io.circe" %% "circe-core" % "0.7.0",
+      "io.circe" %% "circe-generic" % "0.7.0",
+      "io.circe" %% "circe-parser" % "0.7.0"
     )
   ).dependsOn(common)
 
 lazy val json4s = (project in file("parsers/json4s"))
   .settings(
     libraryDependencies ++= Seq(
-      "org.json4s" %% "json4s-native" % "3.3.0",
-      "org.json4s" %% "json4s-jackson" % "3.3.0",
-      "org.spire-math" %% "jawn-json4s" % "0.8.4"
+      "org.json4s" %% "json4s-native" % "3.5.0",
+      "org.json4s" %% "json4s-jackson" % "3.5.0",
+      "org.spire-math" %% "jawn-json4s" % "0.10.4"
     )
   ).dependsOn(common)
 
 lazy val argonaut = (project in file("parsers/argonaut"))
   .settings(
     libraryDependencies ++= Seq(
-      "io.argonaut" %% "argonaut" % "6.1",
-      "org.spire-math" %% "jawn-argonaut" % "0.8.4"
+      "io.argonaut" %% "argonaut" % "6.2-RC2",
+      "io.argonaut" %% "argonaut-jawn" % "6.2-RC2"
     )
   ).dependsOn(common)
 
 lazy val spray = (project in file("parsers/spray"))
   .settings(
     libraryDependencies ++= Seq(
-      "io.spray" %%  "spray-json" % "1.3.2",
-      "org.spire-math" %% "jawn-spray" % "0.8.4"
+      "io.spray" %%  "spray-json" % "1.3.3",
+      "org.spire-math" %% "jawn-spray" % "0.10.4"
     )
   ).dependsOn(common)
 

--- a/parsers/argonaut/src/main/scala/ArgonautReader.scala
+++ b/parsers/argonaut/src/main/scala/ArgonautReader.scala
@@ -3,6 +3,7 @@ package parsers
 import scala.util.Success
 
 import argonaut.Argonaut._
+import argonaut.JawnParser.facade
 import argonaut._
 
 import models._
@@ -11,7 +12,7 @@ import models.bidrequest.device._
 
 object ArgonautReader extends BidRequestReader {
   override def parse(line: String, lastResult: ParsingResult) = {
-    jawn.support.argonaut.Parser.parseFromString(line) match {
+    jawn.Parser.parseFromString(line) match {
       case Success(json) =>
         json.as[BidRequest].fold(
           { case (_, _) => lastResult.incrCannotUnmarshal },

--- a/parsers/circe/src/main/scala/CirceReader.scala
+++ b/parsers/circe/src/main/scala/CirceReader.scala
@@ -1,5 +1,6 @@
 package parsers
 
+import cats.syntax.either._
 import io.circe._
 import io.circe.generic.semiauto._
 
@@ -11,9 +12,9 @@ object CirceReader extends BidRequestReader {
 
   override def parse(line: String, lastResult: ParsingResult): ParsingResult =
     io.circe.jawn.decode[BidRequest](line) match {
-      case cats.data.Xor.Left(ParsingFailure(_, _)) => lastResult.incrCannotParse
-      case cats.data.Xor.Left(DecodingFailure(_, _)) => lastResult.incrCannotUnmarshal
-      case cats.data.Xor.Right(_) => lastResult.incrOk
+      case Left(ParsingFailure(_, _)) => lastResult.incrCannotParse
+      case Left(DecodingFailure(_, _)) => lastResult.incrCannotUnmarshal
+      case Right(_) => lastResult.incrOk
     }
 
   /**

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.11
+sbt.version=0.13.13

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.2.6")
+addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.2.20")


### PR DESCRIPTION
I've updated all library versions (but left 2.11 as the Scala version).

The comparison isn't entirely fair because the circe decoders use generic derivation while the Argonaut ones use the `jdecodeNL` methods—we should really change the circe ones to use `forProductN` for the two to be comparable. As it is circe is at a slight disadvantage (~5-20% in other benchmarks).

New results for circe 0.7 and Argonaut 6.2 (lower is better):

```
Benchmark                         (readerName)  Mode  Cnt   Score   Error  Units
OneFileReadersbenchmarks.bench      spray-jawn  avgt    4   7.249 ± 0.094   s/op
OneFileReadersbenchmarks.bench           spray  avgt    4   9.149 ± 0.082   s/op
OneFileReadersbenchmarks.bench      circe-jawn  avgt    4  12.076 ± 0.143   s/op
OneFileReadersbenchmarks.bench   argonaut-jawn  avgt    4  13.326 ± 0.300   s/op
OneFileReadersbenchmarks.bench       play-jawn  avgt    4  19.646 ± 0.178   s/op
OneFileReadersbenchmarks.bench            play  avgt    4  22.023 ± 0.130   s/op
OneFileReadersbenchmarks.bench     json4s-jawn  avgt    4  30.543 ± 0.774   s/op
OneFileReadersbenchmarks.bench  json4s-jackson  avgt    4  33.504 ± 0.114   s/op
OneFileReadersbenchmarks.bench          json4s  avgt    4  34.678 ± 0.199   s/op
```

Previous results for comparison (circe 0.4, Argonaut 6.1, etc.):

```
Benchmark                         (readerName)  Mode  Cnt   Score   Error  Units
OneFileReadersbenchmarks.bench      spray-jawn  avgt    4   7.290 ± 0.177   s/op
OneFileReadersbenchmarks.bench           spray  avgt    4   9.091 ± 0.063   s/op
OneFileReadersbenchmarks.bench      circe-jawn  avgt    4  14.095 ± 0.145   s/op
OneFileReadersbenchmarks.bench   argonaut-jawn  avgt    4  15.289 ± 0.304   s/op
OneFileReadersbenchmarks.bench       play-jawn  avgt    4  19.414 ± 0.349   s/op
OneFileReadersbenchmarks.bench            play  avgt    4  21.243 ± 0.163   s/op
OneFileReadersbenchmarks.bench     json4s-jawn  avgt    4  30.113 ± 0.382   s/op
OneFileReadersbenchmarks.bench  json4s-jackson  avgt    4  31.282 ± 0.277   s/op
OneFileReadersbenchmarks.bench          json4s  avgt    4  34.493 ± 0.389   s/op
```
